### PR TITLE
Fix resolution of deploy-service url

### DIFF
--- a/util/archive_handler_test.go
+++ b/util/archive_handler_test.go
@@ -1,9 +1,10 @@
-package util
+package util_test
 
 import (
 	"os"
 	"path/filepath"
 
+	"github.com/SAP/cf-mta-plugin/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,13 +14,13 @@ var _ = Describe("ArchiveHandler", func() {
 		var mtaArchiveFilePath, _ = filepath.Abs("../test_resources/commands/mtaArchive.mtar")
 		Context("with valid mta archive", func() {
 			It("should extract and return the id from deployment descriptor", func() {
-				Expect(GetMtaIDFromArchive(mtaArchiveFilePath)).To(Equal("test"))
+				Expect(util.GetMtaIDFromArchive(mtaArchiveFilePath)).To(Equal("test"))
 			})
 		})
 		Context("with valid mta archive and no deployment descriptor provided", func() {
 			It("should return error", func() {
 				mtaArchiveFilePath, _ = filepath.Abs("../test_resources/util/mtaArchiveNoDescriptor.mtar")
-				_, err := GetMtaIDFromArchive(mtaArchiveFilePath)
+				_, err := util.GetMtaIDFromArchive(mtaArchiveFilePath)
 				Expect(err).To(MatchError("Could not get MTA id from archive"))
 			})
 		})
@@ -30,7 +31,7 @@ var _ = Describe("ArchiveHandler", func() {
 				mtaArchiveFilePath, _ = filepath.Abs("test.mtar")
 			})
 			It("should return error for not a valid zip archive", func() {
-				_, err := GetMtaIDFromArchive(mtaArchiveFilePath)
+				_, err := util.GetMtaIDFromArchive(mtaArchiveFilePath)
 				Expect(err).To(MatchError("zip: not a valid zip file"))
 			})
 			AfterEach(func() {

--- a/util/builders_test.go
+++ b/util/builders_test.go
@@ -1,0 +1,42 @@
+package util_test
+
+import (
+	"github.com/SAP/cf-mta-plugin/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UriBuilderTest", func() {
+	Describe("BuildUriTest", func() {
+		const hostName = "test-host"
+		const scheme = "test-scheme"
+		const path = "test-path"
+
+		Context("no scheme and host are provided", func() {
+			It("should return an error", func() {
+				uriBuilder := util.NewUriBuilder().SetPath(path)
+				_, err := uriBuilder.Build()
+
+				Expect(err).Should(MatchError("The host or scheme could not be empty"))
+			})
+		})
+		Context("when scheme and path are provided", func() {
+			It("should return an error", func() {
+				uriBuilder := util.NewUriBuilder().SetScheme(scheme).SetPath(path)
+				_, err := uriBuilder.Build()
+
+				Expect(err).Should(MatchError("The host or scheme could not be empty"))
+			})
+		})
+		Context("when scheme, host and path are provided", func() {
+			It("should the built uri", func() {
+				uriBuilder := util.NewUriBuilder().SetHost(hostName).SetScheme(scheme).SetPath(path)
+				uri, err := uriBuilder.Build()
+
+				Expect(uri).To(Equal("test-scheme://test-host/test-path"))
+				Expect(err).To(BeNil())
+			})
+		})
+
+	})
+})

--- a/util/deploy_service_url_calculator_test.go
+++ b/util/deploy_service_url_calculator_test.go
@@ -1,7 +1,9 @@
-package util
+package util_test
 
 import (
 	cli_fakes "github.com/SAP/cf-mta-plugin/cli/fakes"
+	"github.com/SAP/cf-mta-plugin/util"
+	fakes "github.com/SAP/cf-mta-plugin/util/fakes"
 	plugin_models "github.com/cloudfoundry/cli/plugin/models"
 
 	. "github.com/onsi/ginkgo"
@@ -26,7 +28,8 @@ var _ = Describe("DeployServiceURLCalculator", func() {
 							plugin_models.GetSpace_Domains{Name: "test.ondemand.com", Shared: true},
 						},
 					}, nil).Build()
-				deployServiceURLCalculator := NewDeployServiceURLCalculator(cliConnection)
+				fakeHttpExecutor := fakes.NewFakeHttpGetExecutor(200, nil)
+				deployServiceURLCalculator := util.NewDeployServiceURLCalculatorWithHttpExecutor(cliConnection, fakeHttpExecutor)
 				Expect(deployServiceURLCalculator.ComputeDeployServiceURL()).To(Equal("deploy-service.test.ondemand.com"))
 			})
 		})
@@ -44,7 +47,8 @@ var _ = Describe("DeployServiceURLCalculator", func() {
 							plugin_models.GetSpace_Domains{Name: "test2.ondemand.com", Shared: true},
 						},
 					}, nil).Build()
-				deployServiceURLCalculator := NewDeployServiceURLCalculator(cliConnection)
+				fakeHttpExecutor := fakes.NewFakeHttpGetExecutor(200, nil)
+				deployServiceURLCalculator := util.NewDeployServiceURLCalculatorWithHttpExecutor(cliConnection, fakeHttpExecutor)
 				Expect(deployServiceURLCalculator.ComputeDeployServiceURL()).To(Equal("deploy-service.test1.ondemand.com"))
 			})
 		})
@@ -60,7 +64,7 @@ var _ = Describe("DeployServiceURLCalculator", func() {
 							plugin_models.GetSpace_Domains{Name: "custom.test.ondemand.com", Shared: false},
 						},
 					}, nil).Build()
-				deployServiceURLCalculator := NewDeployServiceURLCalculator(cliConnection)
+				deployServiceURLCalculator := util.NewDeployServiceURLCalculator(cliConnection)
 				_, err := deployServiceURLCalculator.ComputeDeployServiceURL()
 				Expect(err).Should(MatchError("Could not find any shared domains in space: " + spaceName))
 			})
@@ -70,7 +74,7 @@ var _ = Describe("DeployServiceURLCalculator", func() {
 				cliConnection := cli_fakes.NewFakeCliConnectionBuilder().
 					CurrentSpace("", "", nil).
 					Build()
-				deployServiceURLCalculator := NewDeployServiceURLCalculator(cliConnection)
+				deployServiceURLCalculator := util.NewDeployServiceURLCalculator(cliConnection)
 				_, err := deployServiceURLCalculator.ComputeDeployServiceURL()
 				Expect(err).Should(MatchError("No space targeted, use 'cf target -s SPACE' to target a space."))
 			})

--- a/util/fakes/fake_http_simple_executor.go
+++ b/util/fakes/fake_http_simple_executor.go
@@ -1,0 +1,16 @@
+package fakes
+
+import "github.com/SAP/cf-mta-plugin/util"
+
+type fakeHttpGetExecutor struct{
+  statusCode int
+  err error
+}
+
+func NewFakeHttpGetExecutor(statusCode int, err error) util.HttpSimpleGetExecutor{
+  return &fakeHttpGetExecutor{statusCode: statusCode, err: err}
+}
+
+func (f fakeHttpGetExecutor) ExecuteGetRequest(url string) (int, error) {
+  return f.statusCode, f.err
+}

--- a/util/http_util.go
+++ b/util/http_util.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"net/http"
+)
+
+type HttpSimpleGetExecutor interface {
+	ExecuteGetRequest(url string) (int, error)
+}
+
+type SimpleGetExecutor struct {
+}
+
+func NewSimpleGetExecutor() SimpleGetExecutor {
+	return SimpleGetExecutor{}
+}
+
+func (executor SimpleGetExecutor) ExecuteGetRequest(url string) (int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
+}


### PR DESCRIPTION
When there are more than one shared domains, presented in the landscape,
the logic of finding the correct one, was assuming that the first one is
the correct. However, this is not true all the times as the first one
could not be the correct one. This commit introduces a mechanism for
pinging the domains till the right one responds with 200 OK status code.

BUG: LMCROSSITXSADEPLOY-833