### PR TITLE
make build script independent from current dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.8
 install:
   - chmod +x bin/test.sh
-  - chmod +x bin/build.sh
+  - chmod +x build.sh
   - go get -t -v ./...
 script:  bin/test.sh
 branches:

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+
+echo "DEPCRECATED! DO NOT USE THIS SCRIPT. USE THE build.sh in the root durectory of the project!"
 echo -e "Generating binaries..."
 
 ROOT_DIR=$(cd $(dirname $(dirname $0)) && pwd)

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -30,4 +30,4 @@ echo -e "Testing packages..."
 ginkgo -r $@
 
 echo -e "Running build script to confirm everything compiles..."
-bin/build.sh
+./build.sh "0.0.$(date +%s)"

--- a/build.sh
+++ b/build.sh
@@ -27,4 +27,6 @@ function main() {
     done
 }
 
+script_dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
+cd "${script_dir}"
 main "$@"


### PR DESCRIPTION
Make build.sh easy to automate.
Deprecate outdated build script